### PR TITLE
Allow plugin to be installed with composer

### DIFF
--- a/GigyaAction.php
+++ b/GigyaAction.php
@@ -120,12 +120,7 @@ class GigyaAction {
 	 */
 	public function init()
 	{
-		if (!file_exists(GIGYA__PLUGIN_DIR . 'vendor/autoload.php')) {
-			return;
-		}
-
 		/* Require SDK libraries */
-		require_once GIGYA__PLUGIN_DIR . 'vendor/autoload.php';
 		require_once GIGYA__PLUGIN_DIR . 'cms_kit/GigyaJsonObject.php';
 		require_once GIGYA__PLUGIN_DIR . 'cms_kit/GigyaUserFactory.php';
 		require_once GIGYA__PLUGIN_DIR . 'cms_kit/GigyaProfile.php';

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "gigya/wordpress",
   "description": "Integrate your WordPress site with SAP Customer Data Cloud",
-  "type": "project",
+  "type": "wordpress-plugin",
   "license": "Apache 2.0",
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
+    "composer/installers": "^1.9",
     "gigya/php-sdk": "^3.0",
     "ext-json": "*",
     "ext-openssl": "*"


### PR DESCRIPTION
- Add `composer/installers` to enable users of this plugin to install it anywhere
- Change the type to `wordpress-plugin`
- Do not require `vendor/autoload.php` of the plugin folder

Fixes #151 